### PR TITLE
reuse the same local repo for multiple remote hosts

### DIFF
--- a/lib/capistrano/git/copy/tasks/deploy.cap
+++ b/lib/capistrano/git/copy/tasks/deploy.cap
@@ -32,14 +32,14 @@ namespace :git_copy do
 
     system("if [ -d #{local_repo_path} ]; then cd #{local_repo_path} && git fetch origin; else git clone #{fetch(:repo_url)} #{local_repo_path}; fi")
 
+    system("cd #{local_repo_path} && git reset --hard origin/#{fetch(:branch)} && git submodule init && git submodule update && git-archive-all __tmp.tar")
+    system("cd #{local_repo_path} && tar -xf __tmp.tar && cd __tmp && tar -czf #{local_tar_file} .")
+
     on roles :all do
-      system("cd #{local_repo_path} && git reset --hard origin/#{fetch(:branch)} && git submodule init && git submodule update && git-archive-all __tmp.tar")
-      system("cd #{local_repo_path} && tar -xf __tmp.tar && cd __tmp && tar -czf #{local_tar_file} .")
-
       upload!(local_tar_file, "#{fetch(:tmp_dir)}/#{fetch(:application)}_#{fetch(:stage)}.tar.gz")
-
-      system("rm -rf #{local_tar_file}")
     end
+
+    system("rm -rf #{local_tar_file}")
   end
 
   desc 'Extract tar to release path'


### PR DESCRIPTION
When deploying to multiple servers, the git:update task tries to clone/reset the same repo. This causes an error to appear because an index.lock file exists after the first clone/reset.

So I update the repository before the on roles block.
