### PR TITLE
Fixed 'Branch develop (at ) deployed' message 

### DIFF
--- a/lib/capistrano/git/copy/tasks/deploy.cap
+++ b/lib/capistrano/git/copy/tasks/deploy.cap
@@ -47,7 +47,7 @@ namespace :git_copy do
 
   desc 'Determine the revision that will be deployed'
   task set_current_revision: :'git_copy:wrapper' do
-    revision = `cd #{fetch(:local_repo_path)} && git rev-parse --short #{fetch(:branch, 'master')} 2>/dev/null`.strip
+    revision = `cd #{fetch(:local_repo_path)} && git rev-parse origin/#{fetch(:branch, 'master')} 2>/dev/null`.strip
 
     on release_roles :all do
       set :current_revision, revision


### PR DESCRIPTION
Hello,

I have found the following trouble in your gem.

If I set a custom branch name 
```
set :branch, 'develop'
```
then I get the following messages in 'revisions.log
```
Branch develop (at ) deployed as release 20141224180110 by kgovorukha
```
but I think I should get something like this:
```
Branch develop (at 12312312209afa0a5d2a6e29e08b9a5caa123123) deployed as release 20141224180110 by kgovorukha
```

Also 'current/REVISION' file is empty if I set a custom branch.
But after my change it contains a hash of commit which was deployed by Capistrano.

