### PR TITLE
Fixed Git is not a class bug

### DIFF
--- a/lib/capistrano/git/copy/utility.rb
+++ b/lib/capistrano/git/copy/utility.rb
@@ -1,8 +1,9 @@
 require 'tmpdir'
 require 'digest/md5'
+require 'capistrano/scm'
 
 module Capistrano
-  module Git
+  class Git < Capistrano::SCM
     module Copy
       # Utility stuff to avoid cluttering of deploy.cap
       class Utility

--- a/lib/capistrano/git/copy/version.rb
+++ b/lib/capistrano/git/copy/version.rb
@@ -1,7 +1,9 @@
+require 'capistrano/scm'
+
 # Capistrano
 module Capistrano
   # Git
-  module Git
+  class Git < Capistrano::SCM
     # Copy
     module Copy
       # gem version


### PR DESCRIPTION
The original namespace `Capistrano::Git` is not a module but a class, and it is inherited `Capistrano::SCM`.

Once required 'capistrano/git/copy' in Capfile, it will raise exception `TypeError: Git is not a class` when  `set :scm, :git` (without using `:git_copy`)
