### PR TITLE
strip branch name only if it is a string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Unreleased
+### Fixed
+  - strip branch name only if it is a String
+
 ## 0.8.0 (2015-04-07)
 ### Changes
   - changed namespace from Capistrano::Git::Copy to Capistrano::GitCopy to avoid problems when using it in conjunction with build-in git support from capistrano

--- a/lib/capistrano/git_copy/utility.rb
+++ b/lib/capistrano/git_copy/utility.rb
@@ -152,7 +152,8 @@ module Capistrano
       def commit_hash
         return @_commit_hash if @_commit_hash
 
-        branch = fetch(:branch, 'master').strip
+        branch = fetch(:branch, 'master')
+        branch.strip! if branch.is_a?(String)
 
         if test! :git, 'rev-parse', "origin/#{branch}", '>/dev/null 2>/dev/null'
           @_commit_hash = capture(:git, 'rev-parse', "origin/#{branch}").strip


### PR DESCRIPTION
Fix for
```
(Backtrace restricted to imported tasks)
cap aborted!
NoMethodError: undefined method `strip' for :master:Symbol

Tasks: TOP => git_copy:create_release => git_copy:update
(See full trace by running task with --trace)
The deploy has failed with an error: undefined method `strip' for :master:Symbol
```
Cheers, Erik