### PR TITLE
Stringify branch name making commit_hash

### DIFF
--- a/lib/capistrano/git_copy/utility.rb
+++ b/lib/capistrano/git_copy/utility.rb
@@ -153,8 +153,7 @@ module Capistrano
       def commit_hash
         return @_commit_hash if @_commit_hash
 
-        branch = fetch(:branch, 'master')
-        branch.strip! if branch.is_a?(String)
+        branch = fetch(:branch, 'master').to_s.strip
 
         if test! :git, 'rev-parse', "origin/#{branch}", '>/dev/null 2>/dev/null'
           @_commit_hash = capture(:git, 'rev-parse', "origin/#{branch}").strip


### PR DESCRIPTION
Hi,

When I want to specify a branch (, tag or commit) as deploy target from command line, using the environment variable is convenient:

```
set :scm, :git_copy
set :branch, ENV['branch'] || 'master'
```

It may be a familiar way. Then I try it with git_copy, the cap task begins to abort:

```
$ cap stage deploy branch=hotfix
...
...
cap aborted!
can't modify frozen String
```

Because it is going to fail at `branch.strip! if branch.is_a?(String)` in the `Capistrano::GitCopy::Utility`.

Of course, I should do this way:

```
set :branch, ENV['branch'].dup || 'master'
```

or 

```
set :branch, (ENV['branch'] || 'master').to_sym
```

But I think at here. Why is the string called `strip!` ?
And if the variable `branch` is `Symbol`, it does not call `strip!`.

As a result, I'd like to change as this MR.

Thanks