### PR TITLE
require path updated in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ end
 And require it in your `Capfile`:
 
 ```ruby
-require 'capistrano/git/copy'
+require 'capistrano/git_copy'
 ```
 
 Now use `git_copy` as your SCM type in your `config/deploy.rb`:


### PR DESCRIPTION
A small documentation update to avoid confusion in new installations (I got confused by the path as well, so decided to fix the docs).