### PR TITLE
Аn option to deploy without submodules

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ Now use `git_copy` as your SCM type in your `config/deploy.rb`:
 
     set :scm, :git_copy
 
+By default, it includes all submodules into the deployment package. However, 
+if they are not needed in a particular deployment, you can disable them with 
+a configuration option:
+
+    set :with_submodules, false
+
 ## Notes
 
 * Uses [git-archive-all](https://github.com/Kentzo/git-archive-all) for bundling repositories.

--- a/lib/capistrano/git_copy/tasks/deploy.cap
+++ b/lib/capistrano/git_copy/tasks/deploy.cap
@@ -1,3 +1,9 @@
+namespace :load do
+  task :defaults do
+     set :with_submodules, true
+  end
+end
+
 namespace :git_copy do
   def git_copy_utility
     @git_copy_utility ||= Capistrano::GitCopy::Utility.new(self)


### PR DESCRIPTION
There can be cases when all submodules are not needed in each and every deployment session (as, in my case, there were large commercial DB setup files that were needed for cold start and data migration, but were not required for a quick app code update). Of course, a different deployment SCM library could be used, but I thought an extra dependency to be harder to maintain and debug, so that it's always better to stick to one particular solution.

So I thought it could be useful to add a config option for including submodules into the archive. The option is true by default (so that the default system behavior has not changed), but a user can toggle it if desires so (then plain old 'git archive' will be used instead of 'git-archive-all'). Both cases have been tested and seem to work as they were meant to.