### PR TITLE
git-archive-all updated to the latest version

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "vendor/git-archive-all"]
 	path = vendor/git-archive-all
-	url = https://github.com/ydkn/git-archive-all.git
+	url = https://github.com/Kentzo/git-archive-all.git


### PR DESCRIPTION
Fixes this bug: https://github.com/Kentzo/git-archive-all/issues/24 (this bug affected the deployment process on MacOS or any path that contains symlinks, old version's tarballs get broken and are not extracted fully).