### PR TITLE
Update copy.rb to clarify how to remove depreciation warning.

### DIFF
--- a/lib/capistrano/git/copy.rb
+++ b/lib/capistrano/git/copy.rb
@@ -1,1 +1,1 @@
-STDERR.puts("[DEPRECATION] Please change \"require 'capistrano/git/copy'\" to \"require 'capistrano/git_copy'\" in your Capfile.")
+STDERR.puts("[DEPRECATION] Please change \"require 'capistrano/git/copy'\" to \"require 'capistrano/git_copy'\" in your Capfile, and make sure to disable the default require in your Gemfile with 'gem \"capistrano-git-copy\", require: false\"' to make this warning dissapear.")


### PR DESCRIPTION
I had an issue where I was still getting the deprecation warning even though I was not requiring `capistrano/git/copy`. I figured out in the end the issue was that I had not done a `require: false` in my Gemfile. The depreciation message was not very useful.

I looked into 2 solutions:

1. Look at the Capfile to see if the require was correct, and only if it was incorrect show the warning
2. Update the warning on the second reason why this warning would still appear.

The second solution was easier and less error prone.